### PR TITLE
ember-initials/intials: fix `fontFamily` and `fontWeight`

### DIFF
--- a/addon/components/initials/index.js
+++ b/addon/components/initials/index.js
@@ -45,9 +45,9 @@ class InitialsAvatarComponent extends ImageAvatarComponent {
 
   @tracked fontSize = 50;
 
-  @tracked fontWeight = 'Helvetica Neue Light, Arial, sans-serif';
+  @tracked fontWeight = 200;
 
-  @tracked fontFamily = 200;
+  @tracked fontFamily = 'Helvetica Neue Light, Arial, sans-serif';
 
   @tracked textColor = 'white';
 


### PR DESCRIPTION
simple fix